### PR TITLE
quick cmd: track history of quick commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is still a work in progress. So, PRs are welcome and appreciated. As of now
 | `:FlowLauncher` | Launches a [telescope](https://github.com/nvim-telescope/telescope.nvim) interface to manage custom commands. Read the docs [here](https://github.com/arjunmahishi/flow.nvim/wiki/Flow-launcher) |
 | `:FlowRunLastCmd` | Run the previously executed custom command |
 | `:FlowLastOutput` | Show the output of the last run command |
-| `:FlowRunQuickCmd` | Run a shell command without saving it |
+| `:FlowRunQuickCmd` | Run a shell command without saving it. This command maintains a history of previous commands. Navigate the history using `<c-p>` and `<c-n>` |
 
 ## Custom commands
 

--- a/lua/flow/util.lua
+++ b/lua/flow/util.lua
@@ -33,4 +33,67 @@ M.trim_space = function(s)
   return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
+local file_delimiter = ">>>>>>>>>>>>>>>>"
+
+M.table_to_file = function(t, filepath)
+  local file = io.open(filepath, "w")
+  if not file then
+    print("Failed to open file: " .. filepath)
+    return
+  end
+
+  for _, v in ipairs(t) do
+    file:write(v .. "\n" .. file_delimiter .. "\n")
+  end
+
+  file:close()
+end
+
+M.file_to_table = function(filepath)
+  local file = io.open(filepath, "r")
+  if not file then
+    -- print("Failed to open file: " .. filepath)
+    return {}
+  end
+
+  local result = {}
+  local current = {}
+  for line in file:lines() do
+    if line == file_delimiter then
+      table.insert(result, table.concat(current, "\n"))
+      current = {}
+    else
+      table.insert(current, line)
+    end
+  end
+
+  file:close()
+  return result
+end
+
+-- this dedub favors the latest occuring element
+M.dedup = function(t)
+  local result = {}
+  local seen = {}
+  for i = #t, 1, -1 do
+    local v = t[i]
+    if not seen[v] then
+      table.insert(result, 1, v)
+      seen[v] = true
+    end
+  end
+
+  return result
+end
+
+M.tail_n = function(t, n)
+  local result = {}
+  local len = #t
+  for i = len - n + 1, len do
+    table.insert(result, t[i])
+  end
+
+  return result
+end
+
 return M


### PR DESCRIPTION
store the history of executed quick commands on disk. The user can scroll through these this history using <c-p> and <c-n> in insert mode.

The commands are deduped while storing in history. And only the last 100 commands are stored.

Closes #35